### PR TITLE
removing verbose from npm install

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM node:alpine
 WORKDIR '/app'
 
 COPY package.json .
-RUN npm install --verbose
+RUN npm install
 
 COPY . .
 


### PR DESCRIPTION
In this change I have removed the --verbose parameter from npm install command in Dockerfile.dev as no longer needed for debugging.